### PR TITLE
Updates from review discussion

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -165,49 +166,55 @@ func (f *logFormatter) Format(e *log.Entry) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+func dirURL(path string) *url.URL {
+	if path[len(path)-1] != filepath.Separator {
+		// trailing slash is important
+		path = path + string(filepath.Separator)
+	}
+	return &url.URL{Scheme: "file", Path: path}
+}
+
 // JsonnetVM constructs a new jsonnet.VM, according to command line
 // flags
 func JsonnetVM(cmd *cobra.Command) (*jsonnet.VM, error) {
 	vm := jsonnet.MakeVM()
 	flags := cmd.Flags()
 
-	var searchPaths []string
+	var searchUrls []*url.URL
 
-	jpath := os.Getenv("KUBECFG_JPATH")
-	for _, p := range filepath.SplitList(jpath) {
-		log.Debugln("Adding jsonnet search path", p)
-		searchPaths = append(searchPaths, p)
-	}
+	jpathEnv := os.Getenv("KUBECFG_JPATH")
 
-	jpath, err := flags.GetString(flagJpath)
+	jpathArg, err := flags.GetString(flagJpath)
 	if err != nil {
 		return nil, err
 	}
-	for _, p := range filepath.SplitList(jpath) {
-		log.Debugln("Adding jsonnet search path", p)
-		searchPaths = append(searchPaths, p)
+	for _, jpath := range []string{jpathEnv, jpathArg} {
+		for _, p := range filepath.SplitList(jpath) {
+			p, err := filepath.Abs(p)
+			if err != nil {
+				return nil, err
+			}
+			searchUrls = append(searchUrls, dirURL(p))
+		}
 	}
 
 	sURLs, err := flags.GetStringSlice(flagSUrl)
 	if err != nil {
 		return nil, err
 	}
-	for _, u := range sURLs {
-		log.Debugln("Adding jsonnet search path given as URL", u)
-		searchPaths = append(searchPaths, u)
+	for _, ustr := range sURLs {
+		u, err := url.Parse(ustr)
+		if err != nil {
+			return nil, err
+		}
+		searchUrls = append(searchUrls, u)
 	}
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil, err
+	for _, u := range searchUrls {
+		log.Debugln("Jsonnet search path:", u)
 	}
 
-	importer, err := utils.MakeUniversalImporter(wd, searchPaths)
-	if err != nil {
-		return nil, err
-	}
-
-	vm.Importer(importer)
+	vm.Importer(utils.MakeUniversalImporter(searchUrls))
 
 	extvars, err := flags.GetStringSlice(flagExtVar)
 	if err != nil {

--- a/utils/acquire.go
+++ b/utils/acquire.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -126,11 +127,20 @@ func jsonWalk(obj interface{}) ([]interface{}, error) {
 }
 
 func jsonnetReader(vm *jsonnet.VM, path string) ([]runtime.Object, error) {
+	// TODO: Read via Importer, so we support HTTP, etc for first
+	// file too.
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	pathUrl := &url.URL{Scheme: "file", Path: abs}
+
 	bytes, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	jsonstr, err := vm.EvaluateSnippet(path, string(bytes))
+
+	jsonstr, err := vm.EvaluateSnippet(pathUrl.String(), string(bytes))
 	if err != nil {
 		return nil, err
 	}

--- a/utils/importer.go
+++ b/utils/importer.go
@@ -1,16 +1,18 @@
 package utils
 
 import (
+	"errors"
 	"fmt"
-	jsonnet "github.com/google/go-jsonnet"
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path"
-	"path/filepath"
-	"regexp"
 	"strings"
+
+	jsonnet "github.com/google/go-jsonnet"
+	log "github.com/sirupsen/logrus"
 )
+
+var errNotFound = errors.New("Not found")
 
 /*
 MakeUniversalImporter creates an importer that handles resolving imports from the filesystem and http/s.
@@ -29,50 +31,24 @@ A real-world example:
     will be resolved as https://raw.githubusercontent.com/ksonnet/ksonnet-lib/master/ksonnet.beta.2/k8s.libsonnet
 	and downloaded from that location
 */
-func MakeUniversalImporter(fsWorkdir string, searchPathsOrURLs []string) (jsonnet.Importer, error) {
-	var urls []url.URL
-	if !filepath.IsAbs(fsWorkdir) {
-		return nil, fmt.Errorf("Given filesystem workdir %s is not an absolute path", fsWorkdir)
-	}
-	workDirURL := url.URL{Scheme: "file", Path: fsWorkdir}
-
-	for _, p := range searchPathsOrURLs {
-		u, err := url.Parse(p)
-		if err != nil {
-			return nil, fmt.Errorf("Could not parse search path/url %s", p)
-		}
-		if u.IsAbs() {
-			if strings.EqualFold(u.Scheme, "file") && u.Host != "" {
-				return nil, fmt.Errorf("Search path given as an URL %s is invalid: Ensure it begins with file:///", p)
-			}
-			urls = append(urls, *u)
-		} else {
-			if filepath.IsAbs(p) {
-				urls = append(urls, url.URL{Scheme: "file", Path: p})
-			} else {
-				urls = append(urls, joinURL(workDirURL, p))
-			}
-		}
-	}
-
+func MakeUniversalImporter(searchUrls []*url.URL) jsonnet.Importer {
 	t := &http.Transport{}
 	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
 
 	return &universalImporter{
-			WorkDirURL:     workDirURL,
-			BaseSearchURLs: urls,
-			HTTPClient:     &http.Client{Transport: t},
-		},
-		nil
+		BaseSearchURLs: searchUrls,
+		HTTPClient:     &http.Client{Transport: t},
+	}
 }
 
 type universalImporter struct {
-	WorkDirURL     url.URL
-	BaseSearchURLs []url.URL
+	BaseSearchURLs []*url.URL
 	HTTPClient     *http.Client
 }
 
 func (importer *universalImporter) Import(dir, importedPath string) (*jsonnet.ImportedData, error) {
+	log.Debugf("Importing %q from %q", importedPath, dir)
+
 	candidateURLs, err := importer.expandImportToCandidateURLs(dir, importedPath)
 	if err != nil {
 		return nil, fmt.Errorf("Could not get candidate URLs for when importing %s (import dir is %s)", importedPath, dir)
@@ -81,94 +57,64 @@ func (importer *universalImporter) Import(dir, importedPath string) (*jsonnet.Im
 	var tried []string
 	for _, u := range candidateURLs {
 		tried = append(tried, u.String())
-		importedData := importer.tryImport(u)
-		if importedData != nil {
+		importedData, err := importer.tryImport(u)
+		if err == nil {
 			return importedData, nil
+		} else if err != errNotFound {
+			return nil, err
 		}
 	}
 
-	return nil, fmt.Errorf("Could't open import '%s', no match locally or in library search paths. Tried: %s",
+	return nil, fmt.Errorf("Couldn't open import %q, no match locally or in library search paths. Tried: %s",
 		importedPath,
-		strings.Join(tried[:], ";"),
+		strings.Join(tried, ";"),
 	)
 }
 
-func (importer *universalImporter) tryImport(url url.URL) *jsonnet.ImportedData {
+func (importer *universalImporter) tryImport(url *url.URL) (*jsonnet.ImportedData, error) {
 	res, err := importer.HTTPClient.Get(url.String())
-	if err == nil {
-		defer res.Body.Close()
-		if res.StatusCode == http.StatusOK {
-			bodyBytes, err := ioutil.ReadAll(res.Body)
-			if err == nil {
-				return &jsonnet.ImportedData{
-					FoundHere: url.String(),
-					Content:   string(bodyBytes),
-				}
-			}
-		}
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	defer res.Body.Close()
+	log.Debugf("GET %s -> %s", url, res.Status)
+	if res.StatusCode == http.StatusNotFound {
+		return nil, errNotFound
+	} else if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error reading content: %s", res.Status)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &jsonnet.ImportedData{
+		FoundHere: url.String(),
+		Content:   string(bodyBytes),
+	}, nil
 }
 
-func (importer *universalImporter) expandImportToCandidateURLs(dir, importedPath string) ([]url.URL, error) {
+func (importer *universalImporter) expandImportToCandidateURLs(dir, importedPath string) ([]*url.URL, error) {
 	importedPathURL, err := url.Parse(importedPath)
 	if err != nil {
-		return nil, fmt.Errorf("Import path '%s' is not valid", importedPath)
+		return nil, fmt.Errorf("Import path %q is not valid", importedPath)
 	}
 	if importedPathURL.IsAbs() {
-		return []url.URL{*importedPathURL}, nil
-	} else if filepath.IsAbs(importedPath) {
-		return []url.URL{url.URL{Scheme: "file", Path: importedPath}}, nil
+		return []*url.URL{importedPathURL}, nil
 	}
 
 	importDirURL, err := url.Parse(dir)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid import dir '%s'", dir)
+		return nil, fmt.Errorf("Invalid import dir %q", dir)
 	}
 
-	var candidateURLs []url.URL
+	candidateURLs := make([]*url.URL, 0, len(importer.BaseSearchURLs)+1)
 
-	if !importDirURL.IsAbs() {
-		candidateURLs = append(candidateURLs, joinURL(importer.WorkDirURL, dir, importedPath))
-	} else {
-		candidateURLs = append(candidateURLs, joinURL(*importDirURL, importedPath))
+	candidateURLs = append(candidateURLs, importDirURL.ResolveReference(importedPathURL))
+
+	for _, u := range importer.BaseSearchURLs {
+		candidateURLs = append(candidateURLs, u.ResolveReference(importedPathURL))
 	}
 
-	for _, baseSearchURL := range importer.BaseSearchURLs {
-		candidateURLs = append(candidateURLs, joinURL(baseSearchURL, importedPath))
-	}
 	return candidateURLs, nil
-}
-
-func joinURL(url url.URL, relativePaths ...string) url.URL {
-	paths := make([]string, len(relativePaths)+1)
-	paths[0] = filepath.ToSlash(url.Path)
-	for i, p := range relativePaths {
-		paths[i+1] = filepath.ToSlash(p)
-	}
-
-	newURL := url
-	newURL.Path = path.Join(paths...)
-	return newURL
-}
-
-/*
-	Converts a dir value to URL, while fixing up the dir if necessary.
-	The `dir` value that jsonnet calls importer's Import function with is transformed in process - the path
-	is cleaned up, which means that consecutive slashes are compacted into one. That poses a problem where
-	we, for example, return a resouce path as https://domain.com/path/abc/file.libsonnet, but when resolving
-	dependencies the dir comes back as https:/domain.com/path/abc.
-*/
-func dirURL(dir string) (*url.URL, error) {
-	fixupRe := regexp.MustCompile("(?i)(http|https|file):\\/+(.*)")
-	fixupMatch := fixupRe.FindStringSubmatch(dir)
-	if fixupMatch != nil {
-		var slashes = "//"
-		if strings.EqualFold(fixupMatch[1], "file") {
-			slashes = "///"
-		}
-		dir = fmt.Sprintf("%s:%s%s", fixupMatch[1], slashes, fixupMatch[2])
-	}
-
-	return url.Parse(dir)
 }

--- a/utils/importer_test.go
+++ b/utils/importer_test.go
@@ -6,65 +6,17 @@ import (
 	"testing"
 )
 
-func TestJoinURL(t *testing.T) {
-	t.Run("file protocol join", func(t *testing.T) {
-		u := url.URL{Scheme: "file", Host: "", Path: "/home/user/path/abc/cmd"}
-		actual := joinURL(u, "../testdata/lib")
-		expected := url.URL{Scheme: "file", Host: "", Path: "/home/user/path/abc/testdata/lib"}
-		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("Expected %v, got %v", expected, actual)
-		}
-	})
-	t.Run("http protocol join", func(t *testing.T) {
-		u := url.URL{Scheme: "https", Host: "raw.githubusercontent.com", Path: "/ksonnet/ksonnet-lib/master"}
-		actual := joinURL(u, "ksonnet.beta.2")
-		expected := url.URL{Scheme: "https", Host: "raw.githubusercontent.com", Path: "/ksonnet/ksonnet-lib/master/ksonnet.beta.2"}
-		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("Expected %v, got %v", expected, actual)
-		}
-	})
-}
-
-func TestDirURL(t *testing.T) {
-	t.Run("Fixes up http scheme URLs", func(t *testing.T) {
-		actual, _ := dirURL("http:/domain.com/path/abc")
-		expected := url.URL{Scheme: "http", Host: "domain.com", Path: "/path/abc"}
-		if !reflect.DeepEqual(*actual, expected) {
-			t.Errorf("Expected %v, got %v", expected, actual)
-		}
-	})
-	t.Run("Fixes up file scheme URLs", func(t *testing.T) {
-		actual, _ := dirURL("file:/path/abc")
-		expected := url.URL{Scheme: "file", Host: "", Path: "/path/abc"}
-		if !reflect.DeepEqual(*actual, expected) {
-			t.Errorf("Expected %v, got %v", expected, actual)
-		}
-	})
-
-}
-
 func TestExpandImportToCandidateURLs(t *testing.T) {
 	importer := universalImporter{
-		WorkDirURL: url.URL{Scheme: "file", Path: "/workdir/path"},
-		BaseSearchURLs: []url.URL{
-			url.URL{Scheme: "file", Path: "/first/base/search"},
+		BaseSearchURLs: []*url.URL{
+			{Scheme: "file", Path: "/first/base/search/"},
 		},
 	}
 
 	t.Run("Absolute URL in import statement yields a single candidate", func(t *testing.T) {
 		urls, _ := importer.expandImportToCandidateURLs("dir", "http://absolute.com/import/path")
-		expected := []url.URL{
-			url.URL{Scheme: "http", Host: "absolute.com", Path: "/import/path"},
-		}
-		if !reflect.DeepEqual(urls, expected) {
-			t.Errorf("Expected %v, got %v", expected, urls)
-		}
-	})
-
-	t.Run("Absolute filesystem path in import statement yields a single candidate", func(t *testing.T) {
-		urls, _ := importer.expandImportToCandidateURLs("dir", "/absolute/fs/path")
-		expected := []url.URL{
-			url.URL{Scheme: "file", Host: "", Path: "/absolute/fs/path"},
+		expected := []*url.URL{
+			{Scheme: "http", Host: "absolute.com", Path: "/import/path"},
 		}
 		if !reflect.DeepEqual(urls, expected) {
 			t.Errorf("Expected %v, got %v", expected, urls)
@@ -72,21 +24,10 @@ func TestExpandImportToCandidateURLs(t *testing.T) {
 	})
 
 	t.Run("Absolute URL in import dir is searched before BaseSearchURLs", func(t *testing.T) {
-		urls, _ := importer.expandImportToCandidateURLs("file:///abs/import/dir", "relative/file.libsonnet")
-		expected := []url.URL{
-			url.URL{Scheme: "file", Host: "", Path: "/abs/import/dir/relative/file.libsonnet"},
-			url.URL{Scheme: "file", Host: "", Path: "/first/base/search/relative/file.libsonnet"},
-		}
-		if !reflect.DeepEqual(urls, expected) {
-			t.Errorf("Expected %v, got %v", expected, urls)
-		}
-	})
-
-	t.Run("Relative import is combined with workdir and search paths", func(t *testing.T) {
-		urls, _ := importer.expandImportToCandidateURLs("../dir", "file.libsonnet")
-		expected := []url.URL{
-			url.URL{Scheme: "file", Host: "", Path: "/workdir/dir/file.libsonnet"},
-			url.URL{Scheme: "file", Host: "", Path: "/first/base/search/file.libsonnet"},
+		urls, _ := importer.expandImportToCandidateURLs("file:///abs/import/dir/", "relative/file.libsonnet")
+		expected := []*url.URL{
+			{Scheme: "file", Host: "", Path: "/abs/import/dir/relative/file.libsonnet"},
+			{Scheme: "file", Host: "", Path: "/first/base/search/relative/file.libsonnet"},
 		}
 		if !reflect.DeepEqual(urls, expected) {
 			t.Errorf("Expected %v, got %v", expected, urls)

--- a/vendor/github.com/google/go-jsonnet/ast/ast.go
+++ b/vendor/github.com/google/go-jsonnet/ast/ast.go
@@ -520,6 +520,15 @@ type ObjectComp struct {
 
 // ---------------------------------------------------------------------------
 
+// Parens represents parentheses
+//   ( e )
+type Parens struct {
+	NodeBase
+	Inner        Node
+}
+
+// ---------------------------------------------------------------------------
+
 // Self represents the self keyword.
 type Self struct{ NodeBase }
 

--- a/vendor/github.com/google/go-jsonnet/desugarer.go
+++ b/vendor/github.com/google/go-jsonnet/desugarer.go
@@ -560,6 +560,13 @@ func desugar(astPtr *ast.Node, objLevel int) (err error) {
 		}
 		*astPtr = comp
 
+	case *ast.Parens:
+		*astPtr = node.Inner
+		err = desugar(astPtr, objLevel)
+		if err != nil {
+			return err
+		}
+
 	case *ast.Self:
 		// Nothing to do.
 

--- a/vendor/github.com/google/go-jsonnet/interpreter.go
+++ b/vendor/github.com/google/go-jsonnet/interpreter.go
@@ -412,11 +412,11 @@ func (i *interpreter) evaluate(a ast.Node, tc tailCallStatus) (value, error) {
 		return nil, e.Error(fmt.Sprintf("Value non indexable: %v", reflect.TypeOf(targetValue)))
 
 	case *ast.Import:
-		codeDir := path.Dir(node.Loc().FileName)
+		codeDir, _ := path.Split(node.Loc().FileName)
 		return i.importCache.ImportCode(codeDir, node.File.Value, e)
 
 	case *ast.ImportStr:
-		codeDir := path.Dir(node.Loc().FileName)
+		codeDir, _ := path.Split(node.Loc().FileName)
 		return i.importCache.ImportString(codeDir, node.File.Value, e)
 
 	case *ast.LiteralBoolean:

--- a/vendor/github.com/google/go-jsonnet/parser/context.go
+++ b/vendor/github.com/google/go-jsonnet/parser/context.go
@@ -99,6 +99,8 @@ func directChildren(node ast.Node) []ast.Node {
 			spec = spec.Outer
 		}
 		return result
+	case *ast.Parens:
+		return []ast.Node{node.Inner}
 	case *ast.Self:
 		return nil
 	case *ast.SuperIndex:
@@ -171,6 +173,8 @@ func thunkChildren(node ast.Node) []ast.Node {
 	case *ast.ArrayComp:
 		return []ast.Node{node.Body}
 	case *ast.ObjectComp:
+		return nil
+	case *ast.Parens:
 		return nil
 	case *ast.Self:
 		return nil

--- a/vendor/github.com/google/go-jsonnet/parser/parser.go
+++ b/vendor/github.com/google/go-jsonnet/parser/parser.go
@@ -724,11 +724,14 @@ func (p *parser) parseTerminal() (ast.Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		_, err = p.popExpect(tokenParenR)
+		tokRight, err := p.popExpect(tokenParenR)
 		if err != nil {
 			return nil, err
 		}
-		return inner, nil
+		return &ast.Parens{
+			NodeBase: ast.NewNodeBaseLoc(locFromTokens(tok, tokRight)),
+			Inner: inner,
+		}, nil
 
 	// Literals
 	case tokenNumber:

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -171,22 +171,22 @@
 			"revisionTime": "2017-08-16T00:15:14Z"
 		},
 		{
-			"checksumSHA1": "n3Q/VKITvz2iOcqZ9UFG6LE67EY=",
+			"checksumSHA1": "NAmZv9H7LyKNu3KKoQc7beqUg0E=",
 			"path": "github.com/google/go-jsonnet",
-			"revision": "f46dea2835bc4d5138d279753643c970250ef683",
-			"revisionTime": "2018-02-01T19:21:39Z"
+			"revision": "bed2cd89bc517714e591781928a856c29611422d",
+			"revisionTime": "2018-02-17T19:17:52Z"
 		},
 		{
-			"checksumSHA1": "UjLF8Vwca8pHJZovPq8tw64LK/0=",
+			"checksumSHA1": "l8detOFllmUMKl/FR8XeA45N5uI=",
 			"path": "github.com/google/go-jsonnet/ast",
-			"revision": "f46dea2835bc4d5138d279753643c970250ef683",
-			"revisionTime": "2018-02-01T19:21:39Z"
+			"revision": "bed2cd89bc517714e591781928a856c29611422d",
+			"revisionTime": "2018-02-17T19:17:52Z"
 		},
 		{
-			"checksumSHA1": "bAHDsLfmK8DrAYw4hFaKtbhwruc=",
+			"checksumSHA1": "Rep/ahvPkiXb89h+WzJTm48zAYc=",
 			"path": "github.com/google/go-jsonnet/parser",
-			"revision": "f46dea2835bc4d5138d279753643c970250ef683",
-			"revisionTime": "2018-02-01T19:21:39Z"
+			"revision": "bed2cd89bc517714e591781928a856c29611422d",
+			"revisionTime": "2018-02-17T19:17:52Z"
 		},
 		{
 			"checksumSHA1": "fgPBEKvm7D7y4IMxGaxHsPmtYtU=",


### PR DESCRIPTION
- Update go-jsonnet to include google/go-jsonnet#191
- Refactor search path construction to build URLs at the outset
- Don't search initial cwd explicitly - files are relative to the
  location of the file doing the import, or searched along search path
- Drop `WorkDirURL` and related logic - no longer needed
- Ensure initial file is imported as an absolute (file://) URL
- Raise errors other than not-found during search